### PR TITLE
Cert pinning (and fix nachocove/qa#156)

### DIFF
--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -298,7 +298,11 @@ namespace ModernHttpClient
                 }
 
             sslErrorVerify:
-                bool result = ServicePointManager.ServerCertificateValidationCallback(this, root, chain, errors);
+                // NachoCove: Add this to make it look like other HTTP client
+                var url = task.CurrentRequest.Url.ToString ();
+                var request = new HttpWebRequest (new Uri (url));
+                // End of NachoCove
+                bool result = ServicePointManager.ServerCertificateValidationCallback(request, root, chain, errors);
                 if (result) {
                     completionHandler(
                         NSUrlSessionAuthChallengeDisposition.UseCredential,


### PR DESCRIPTION
- Make the check cert callback to return a HttpWebRequest instead of DataTaskDelegate.
- The crash in qa#156 occurs because AS SM changes the the callback pointer to ServerCertificatePeek method which tries to cast a DataTaskDelegate into a HttpWebRequest.
- This fixes the crash and is needed for supporting cert pinning.
