### PR TITLE
Disable URL cache properly

### DIFF
--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -49,7 +49,7 @@ namespace ModernHttpClient
             var config = NSUrlSessionConfiguration.DefaultSessionConfiguration;
             config.TimeoutIntervalForRequest = 1000;
             config.TimeoutIntervalForResource = 1000;
-            config.URLCache = null;
+            config.URLCache = new NSUrlCache (0, 0, "HttpClientCache");
             session = NSUrlSession.FromConfiguration(
                 config, 
                 new DataTaskDelegate(this), null);


### PR DESCRIPTION
iOS documenation says to disable URL cache, set it to nil. But Xamarin binding does not allow null to be passed into NSUrlCache. So, set it to a zero-size cache.
