### PR TITLE
Fix nachocove/qa#941

### DIFF
--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -285,7 +285,12 @@ namespace ModernHttpClient
                 chain.ChainPolicy.UrlRetrievalTimeout = new TimeSpan(0, 1, 0);
                 chain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
 
-                if (!chain.Build(root)) {
+                try { 
+                    if (!chain.Build(root)) {
+                        errors = SslPolicyErrors.RemoteCertificateChainErrors;
+                        goto sslErrorVerify;
+                    }
+                } catch (Exception) {
                     errors = SslPolicyErrors.RemoteCertificateChainErrors;
                     goto sslErrorVerify;
                 }


### PR DESCRIPTION
- See nachocove/qa#941 for the analysis of the crash.
- Without a root cause, catch the exception and process it as a remote cert error.
- Hopefully, the root cause would be addressed in the ModernHttpClient upgrade.
